### PR TITLE
Fix a couple errors: can't subtract offset-naive and offset-aware datetimes

### DIFF
--- a/template_sensors.yaml
+++ b/template_sensors.yaml
@@ -21,7 +21,7 @@
         {% set last_delivery = states('sensor.amerigas_last_delivery_gallons') | float(0) %}
         {% set remaining = states('sensor.propane_tank_gallons_remaining') | float(0) %}
         {% set used = last_delivery - remaining %}
-        {{ used if used >= 0 else 0 | round(2) }}
+        {{ (used if used >= 0 else 0) | round(2) }}
     
     # Propane Consumed in Cubic Feet (for Energy Dashboard)
     - name: "Propane Energy Consumption"
@@ -51,7 +51,7 @@
         {% if last_delivery_date not in ['Unknown', 'unknown', 'unavailable', 'none', 'None'] %}
           {% set delivery_datetime = as_datetime(last_delivery_date) %}
           {% if delivery_datetime is not none %}
-            {% set days_since = (now() - delivery_datetime).days %}
+            {% set days_since = (now().date() - delivery_datetime.date()).days %}
             {% if days_since > 0 %}
               {{ (used / days_since) | round(2) }}
             {% else %}
@@ -147,7 +147,8 @@
         {% if last_delivery_date not in ['Unknown', 'unknown', 'unavailable', 'none', 'None'] %}
           {% set delivery_datetime = as_datetime(last_delivery_date) %}
           {% if delivery_datetime is not none %}
-            {{ (now() - delivery_datetime).days }}
+            {% set days_since = (now().date() - delivery_datetime.date()).days %}
+            {{ days_since if days_since > 0 else 0 }}
           {% else %}
             {{ 0 }}
           {% endif %}


### PR DESCRIPTION
## Description
I am running Home Assistant core 2025.11.1, pyscript 1.6.4. These are the latest versions as of this writing.

After installing ha-amerigas, it did not work and in the logs I saw:

```
homeassistant  | ESC[31m2025-11-13 22:56:26.595 ERROR (MainThread) [homeassistant.components.template.template_entity] TemplateError('TypeError: can't subtract offset-naive and offset-aware dat
etimes') while processing template 'Template<template=({% set last_delivery_date = states('sensor.amerigas_last_delivery_date') %} {% set used = states('sensor.propane_used_since_last_delivery'
) | float(0) %}
homeassistant  | {% if last_delivery_date not in ['Unknown', 'unknown', 'unavailable', 'none', 'None'] %}
homeassistant  |   {% set delivery_datetime = as_datetime(last_delivery_date) %}
homeassistant  |   {% if delivery_datetime is not none %}
homeassistant  |     {% set days_since = (now() - delivery_datetime).days %}
homeassistant  |     {% if days_since > 0 %}
homeassistant  |       {{ (used / days_since) | round(2) }}
homeassistant  |     {% else %}
homeassistant  |       {{ 0 }}
homeassistant  |     {% endif %}
homeassistant  |   {% else %}
homeassistant  |     {{ 0 }}
homeassistant  |   {% endif %}
homeassistant  | {% else %}
homeassistant  |   {{ 0 }}
homeassistant  | {% endif %}) renders=2>' for attribute '_attr_native_value' in entity 'sensor.propane_daily_average_usage'ESC[0m
```

Since I'm not particularly familiar with this syntax, I worked with ChatGPT to understand and fix the issue; `now()` returns a timezone-aware datetime, while `delivery_datetime` is a timezone-naive datetime, and Python doesn't allow subtracting these types.

There were two instances of this type of error in the file so I corrected them both; then the script worked and I have AmeriGas data in my HA now. I don't know why it's broken out of the box, but maybe this is due to my HA being newer than yours, or a different Python version.

Additionally, I fed the whole file to ChatGPT and it suggested one other fix, which is an order of operations issue, that I also fixed in this PR.

```
used if used >= 0 else 0 | round(2)

  due to order of operations, it's treated like:

used if used >= 0 else (0 | round(2))

  ...which doesn't do anything... so the suggested fix is

(used if used >= 0 else 0) | round(2)
```

I suggest you double-check the sensors still work as expected. If these sensors lose accuracy due to converting to days, then you may want to fix it a different way. I wouldn't know what the sensors looked like before, since it was broken for me from the beginning.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] Tested in development environment
- [x] All sensors work correctly
- [x] No errors in logs
- [ ] Automations tested (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No breaking changes (or documented)
- [x] Commit messages follow guidelines
