### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   validate:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
         - uses: "actions/checkout@v4"
         - uses: "home-assistant/actions/hassfest@master"


### PR DESCRIPTION
Potential fix for [https://github.com/skircr115/ha-amerigas/security/code-scanning/1](https://github.com/skircr115/ha-amerigas/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow or job so that the GITHUB_TOKEN has only the minimal scopes required. For a validation-only job like this, `contents: read` is typically sufficient, since the job only needs to fetch the repository code and run hassfest; it does not need to push commits, create releases, or modify issues/PRs.

The best minimally invasive fix is to add a `permissions` block under the `validate` job (indented to align with `runs-on`) specifying `contents: read`. This keeps the permissions scoped to this job only, avoids changing behavior of any other workflows or jobs, and clearly documents that the job is read-only. Concretely, in `.github/workflows/hassfest.yml`, insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: "ubuntu-latest"` and `steps:`. No additional methods, imports, or definitions are required, since this is entirely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
