### PR TITLE
Skircr115 v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-03-08
+
+### 🔐 New Feature — In-Place Credential Updates
+
+Users can now update their AmeriGas username or password without deleting and re-adding the integration. A **Configure** button now appears on the AmeriGas integration card under **Settings → Devices & Services**. The credentials are validated before saving; if validation fails the form stays open with an error. The update takes effect on the next coordinator refresh with no restart required and no loss of historical data or Energy Dashboard statistics.
+
+**Implementation**: Added `OptionsFlow` class to `config_flow.py` and wired it via `async_get_options_flow()` on `ConfigFlow`. The username field is pre-filled with the current value so users only need to re-enter the password. Per HA 2025.12+ requirements, `config_entry` is accessed as a read-only injected property rather than being passed to `__init__` — passing it manually caused an `AttributeError` (500 Internal Server Error) in earlier implementations.
+
+### 📊 Enhancement — Daily Average Usage: Proper Unit & Device Class
+
+`sensor.propane_daily_average_usage` now declares `SensorDeviceClass.VOLUME_FLOW_RATE` and uses `UnitOfVolumeFlowRate.GALLONS_PER_DAY` (`gal/d`) instead of the previous bare string `gal/day`. This is the correct HA representation for a consumption rate and enables proper unit conversion in the UI and Lovelace cards.
+
+**Migration note for existing installs**: Home Assistant will display a one-time unit-change prompt under **Developer Tools → Statistics** for `propane_daily_average_usage`. Accepting it corrects the historical unit metadata without altering the underlying recorded values.
+
+### 💳 Enhancement — Last Payment Date Fully Timestamp-Aware
+
+`sensor.amerigas_last_payment_date` previously received the raw string from the API layer and relied on HA to interpret it. The `api.py` `_parse_account_data()` method now parses `LastPaymentDate` through `parse_date()` and returns a timezone-aware `datetime`, consistent with every other date field. This ensures `SensorDeviceClass.TIMESTAMP` rendering is correct and prevents display inconsistencies for users with non-UTC timezones.
+
+### 💳 Enhancement — Payment Terms Days Attribute
+
+`sensor.amerigas_amount_due` now exposes a `payment_terms_days` integer attribute parsed from the `PaymentTermsUpDate` string (e.g. `"Due within 1 day"` → `1`, `"Due within 30 days"` → `30`). Falls back to `30` if the field is absent or unparseable. This value is used internally by cost-per-gallon correlation logic and is also available for automations (e.g. alert if payment is due within N days).
+
+### 🔧 Technical Changes
+
+**`config_flow.py`**
+- Added `OptionsFlow` class implementing `async_step_init()` with credential pre-fill and full validation
+- Added `async_get_options_flow()` static method to `ConfigFlow` returning `OptionsFlow()`
+- `OptionsFlow` uses HA 2025.12+ pattern: no `__init__` override; `self.config_entry` accessed as injected property
+- `async_update_entry()` called on successful validation to apply credential changes in place
+
+**`api.py` — `_parse_account_data()`**
+- `last_payment_date` now assigned via `parse_date()` instead of passing the raw string
+- Added `payment_terms_days` field: integer extracted from `PaymentTermsUpDate` via `re.search(r'\d+', ...)`; defaults to `30`
+
+**`sensor.py` — `PropaneDailyAverageUsageSensor`**
+- `_attr_native_unit_of_measurement` changed from `"gal/day"` to `UnitOfVolumeFlowRate.GALLONS_PER_DAY`
+- `_attr_device_class` added: `SensorDeviceClass.VOLUME_FLOW_RATE`
+
+**`sensor.py` — `AmeriGasAmountDueSensor`**
+- `extra_state_attributes` now includes `payment_terms_days` integer alongside the existing `payment_terms` raw string
+
+**`manifest.json`**
+- Version bumped to `3.1.0`
+
+### 🔄 Migration Notes
+
+No breaking changes. Update via HACS and restart. All existing sensors, entity IDs, automations, and Energy Dashboard configuration continue working without modification.
+
+If Home Assistant shows a Statistics unit-change prompt for `propane_daily_average_usage`, accept it — this is expected and safe.
+
+---
+
 ## [3.0.11] - 2026-02-28
 
 ### 🐛 Bug Fix — Date Timezone Handling

--- a/README.md
+++ b/README.md
@@ -9,13 +9,23 @@
 
 ---
 
-## ✨ What's New in v3.0.11
+## ✨ What's New in v3.1.0
 
-### 🐛 Date Timezone Fix
+### 🔐 Update Credentials Without Reinstalling
 
-All date sensors (last delivery date, next delivery date, last tank reading, last payment date) were displaying one day early for users in US timezones. Date-only strings returned by the AmeriGas API have no timezone context, and the previous code attached UTC to them — causing Home Assistant to shift them back when converting to local time. Dates are now treated as local time using the HA-configured timezone, so they display correctly regardless of UTC offset.
+You can now update your AmeriGas username or password directly from the integration's Configure dialog — no need to delete and re-add the integration. Go to **Settings → Devices & Services → AmeriGas → Configure** and enter your updated credentials. The change takes effect on the next data refresh with no restart required and no loss of historical data.
 
-The next delivery date entity was also disappearing for some users after the v3.0.8 timezone strip workaround (`replace(tzinfo=None)`) produced a naive datetime that Home Assistant rejected for `SensorDeviceClass.TIMESTAMP` sensors. That workaround is now removed entirely. If the entity was deleted, it will be recreated automatically on restart after updating.
+### 📊 Daily Average Usage — Proper Unit & Device Class
+
+`sensor.propane_daily_average_usage` now uses `gal/d` (gallons per day) with `SensorDeviceClass.VOLUME_FLOW_RATE`, the correct HA representation for a flow rate. Previously the sensor used a plain `gal/day` string unit with no device class, which caused inconsistent display and prevented unit conversion in the UI.
+
+**Migration note:** If you had this sensor tracked in the Statistics database before v3.1.0, Home Assistant will show a one-time unit-change prompt under **Developer Tools → Statistics**. Accepting it is safe and expected — it corrects the historical unit metadata without affecting the underlying values.
+
+### 💳 Payment Date & Terms Improvements
+
+`sensor.amerigas_last_payment_date` now correctly uses `SensorDeviceClass.TIMESTAMP` end-to-end: the API layer returns a timezone-aware `datetime` object instead of the raw string it previously passed through. This prevents subtle display issues and makes the sensor consistent with all other date sensors.
+
+`sensor.amerigas_amount_due` gains a new `payment_terms_days` attribute (integer) parsed from the `PaymentTermsUpDate` field (e.g. `"Due within 1 day"` → `1`). This is used internally to improve cost-per-gallon accuracy but is also available for automations.
 
 ---
 
@@ -48,11 +58,12 @@ The next delivery date entity was also disappearing for some users after the v3.
 ## 📦 Installation
 
 ### HACS (Recommended)
-
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=skircr115&repository=ha-amerigas&category=Integration)
+ 
+ -OR-
 1. Open HACS → Integrations
-2. Click ⋮ → Custom repositories
-3. Add `https://github.com/skircr115/ha-amerigas` (Category: Integration)
-4. Install "AmeriGas Propane" and restart Home Assistant
+2. Search for "AmeriGas Propane"
+4. Install and restart Home Assistant
 
 ### Manual
 
@@ -67,6 +78,10 @@ The next delivery date entity was also disappearing for some users after the v3.
 1. **Settings** → **Devices & Services** → **+ Add Integration**
 2. Search "AmeriGas" and select it
 3. Enter your MyAmeriGas account credentials and click **Submit**
+
+### Updating Credentials (v3.1.0+)
+
+If your password changes, go to **Settings → Devices & Services → AmeriGas → Configure** and re-enter your credentials. No restart needed and no historical data is lost.
 
 ### What Gets Created
 
@@ -139,6 +154,10 @@ Data refreshes automatically at **00:00, 06:00, 12:00, and 18:00** daily, plus i
 
 ## 🔧 Troubleshooting
 
+**Need to update your password?** — Use Settings → Devices & Services → AmeriGas → Configure (v3.1.0+). No reinstall required.
+
+**Daily Average Usage unit change prompt in Statistics** — Expected after upgrading to v3.1.0. Go to Developer Tools → Statistics, find `propane_daily_average_usage`, and accept the unit fix. Safe to confirm.
+
 **Date sensors showing the wrong day (one day early)** — Fixed in v3.0.11. Update and restart.
 
 **Next delivery date entity missing / HA prompting you to delete it** — Fixed in v3.0.11. Update and restart; the entity will be recreated automatically.
@@ -193,7 +212,7 @@ entities:
 ## 🔄 Upgrading
 
 ### From any v3.0.x
-No breaking changes across the v3.0.x series. Update via HACS and restart. All sensors, entities, and automations continue working without modification.
+No breaking changes. Update via HACS and restart. All sensors, entities, and automations continue working without modification. If upgrading from a version prior to v3.1.0, see the Daily Average Usage note in the Troubleshooting section above.
 
 ### From v2.x (pyscript)
 See [MIGRATION.md](MIGRATION.md) for detailed instructions.

--- a/custom_components/amerigas/api.py
+++ b/custom_components/amerigas/api.py
@@ -237,7 +237,7 @@ class AmeriGasAPI:
             # Financial
             'amount_due': safe_float(account_data.get('AmounDue'), 0.0),
             'account_balance': safe_float(account_data.get('AccountBalance'), 0.0),
-            'last_payment_date': account_data.get('LastPaymentDate'),
+            'last_payment_date': parse_date(account_data.get('LastPaymentDate')),
             'last_payment_amount': safe_float(account_data.get('LastPaymentAmount'), 0.0),
             
             # Tank Monitor

--- a/custom_components/amerigas/api.py
+++ b/custom_components/amerigas/api.py
@@ -6,7 +6,7 @@ import base64
 import json
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from homeassistant.util import dt as dt_util
@@ -26,36 +26,36 @@ class AmeriGasAuthError(AmeriGasAPIError):
 
 class AmeriGasAPI:
     """API client for AmeriGas customer portal."""
-    
+
     def __init__(self, username: str, password: str) -> None:
         """Initialize the API client."""
         self.username = username
         self.password = password
         self._session: aiohttp.ClientSession | None = None
-    
+
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create aiohttp session."""
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
             _LOGGER.debug("Created new aiohttp session")
         return self._session
-    
+
     async def close(self) -> None:
         """Close the aiohttp session."""
         if self._session and not self._session.closed:
             await self._session.close()
             _LOGGER.debug("Closed aiohttp session")
             self._session = None
-    
+
     async def async_get_data(self) -> dict[str, Any]:
         """Fetch data from AmeriGas portal."""
         try:
             # Login and get dashboard data
             account_data = await self._async_fetch_dashboard()
-            
+
             # Parse and return clean data
             return self._parse_account_data(account_data)
-            
+
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Network error: {err}")
             raise AmeriGasAPIError(f"Network error: {err}") from err
@@ -65,7 +65,7 @@ class AmeriGasAPI:
         finally:
             # Close session after each fetch to prevent unclosed connection warnings
             await self.close()
-    
+
     async def _async_fetch_dashboard(self) -> dict[str, Any]:
         """Login and fetch dashboard data."""
         session = await self._get_session()
@@ -73,20 +73,20 @@ class AmeriGasAPI:
         # Base64 encode credentials
         encoded_email = base64.b64encode(self.username.encode()).decode()
         encoded_password = base64.b64encode(self.password.encode()).decode()
-        
+
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             'Accept': 'application/json, text/javascript, */*; q=0.01',
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
             'X-Requested-With': 'XMLHttpRequest'
         }
-        
+
         login_data = {
             'loginViewModel[EmailAddress]': encoded_email,
             'loginViewModel[Password]': encoded_password,
             'loginViewModel[SAPErrorMessage]': ''
         }
-        
+
         # Login
         async with session.post(
             API_LOGIN_URL,
@@ -96,12 +96,12 @@ class AmeriGasAPI:
         ) as response:
             if response.status != 200:
                 raise AmeriGasAuthError(f"Login failed with status {response.status}")
-            
+
             login_result = await response.json()
             if not login_result.get('success'):
                 error_msg = login_result.get('message', 'Unknown error')
                 raise AmeriGasAuthError(f"Login failed: {error_msg}")
-        
+
         # Get dashboard
         async with session.get(
             API_DASHBOARD_URL,
@@ -109,18 +109,18 @@ class AmeriGasAPI:
         ) as response:
             if response.status != 200:
                 raise AmeriGasAPIError(f"Dashboard fetch failed with status {response.status}")
-            
+
             dashboard_text = await response.text()
-        
+
         # Parse accountSummaryViewModel from JavaScript
         pattern = r'accountSummaryViewModel\s*=\s*({.*?});'
         match = re.search(pattern, dashboard_text, re.DOTALL)
-        
+
         if not match:
             raise AmeriGasAPIError("Could not find accountSummaryViewModel in page")
-        
+
         return json.loads(match.group(1))
-    
+
     def _parse_account_data(self, account_data: dict[str, Any]) -> dict[str, Any]:
         """Parse raw account data into clean format."""
         # Helper functions
@@ -133,33 +133,33 @@ class AmeriGasAPI:
                 return float(value)
             except (ValueError, TypeError):
                 return default
-        
+
         def safe_int(value, default=0):
             try:
                 return int(value) if value else default
             except (ValueError, TypeError):
                 return default
-        
+
         def parse_date(date_str):
             """Parse AmeriGas date in multiple formats, always returns timezone-aware datetime.
-            
+
             Naive datetimes (date-only strings like MM/DD/YYYY) are treated as local time
             using the HA-configured timezone, so dates never roll back a day due to UTC offset.
             Datetimes that already carry timezone info are left unchanged.
             """
             if not date_str or date_str in ['', 'N/A', 'Unknown', 'None']:
                 return None
-            
+
             try:
                 dt_obj = None
-                
+
                 # ISO format with T
                 if 'T' in str(date_str):
                     if date_str.endswith('Z'):
                         dt_obj = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
                     else:
                         dt_obj = datetime.fromisoformat(date_str)
-                
+
                 # US date format
                 elif '/' in str(date_str):
                     parts = str(date_str).split('/')
@@ -168,35 +168,41 @@ class AmeriGasAPI:
                             dt_obj = datetime.strptime(str(date_str), '%m/%d/%y')
                         else:
                             dt_obj = datetime.strptime(str(date_str), '%m/%d/%Y')
-                
+
                 # Fallback
                 else:
                     dt_obj = datetime.fromisoformat(str(date_str))
-                
+
                 if dt_obj:
                     if dt_obj.tzinfo is None:
                         # Treat as local time — date-only strings have no timezone context,
                         # so attaching UTC would cause them to roll back a day for US timezones.
                         dt_obj = dt_obj.replace(tzinfo=dt_util.get_default_time_zone())
                     return dt_obj
-                
+
                 return None
-                
+
             except (ValueError, AttributeError, TypeError) as e:
                 _LOGGER.warning(f"Could not parse date '{date_str}': {e}")
                 return None
-        
+
         # Extract delivery data
         my_orders = account_data.get('myOrdersViewModel', {})
         one_click = my_orders.get('OneClickOrderViewModel', {}) if my_orders else {}
-        
+
         last_delivery_date_raw = one_click.get('LastDeliveryDate', '') if one_click else ''
         last_delivery_gallons = safe_float(one_click.get('LastDeliveredGallons'), 0.0) if one_click else 0.0
-        
+
         # Parse dates
         last_tank_reading = parse_date(account_data.get('TMReadDate', ''))
         last_delivery_date = parse_date(last_delivery_date_raw)
-        
+
+        # v3.0.12: Parse payment date as a timezone-aware datetime for correlation logic.
+        # The raw string is no longer exposed — the parsed datetime is the only form used,
+        # consistent with all other date fields. Previously returned raw string which meant
+        # AmeriGasLastPaymentDateSensor could not use SensorDeviceClass.TIMESTAMP correctly.
+        last_payment_date = parse_date(account_data.get('LastPaymentDate', ''))
+
         # Next delivery date - check open orders first, then fall back
         next_delivery_date_raw = None
         if my_orders:
@@ -210,58 +216,67 @@ class AmeriGasAPI:
                 # 3. General order date if window not set
                 if not next_delivery_date_raw:
                     next_delivery_date_raw = open_orders[0].get('orderDate')
-        
+
         # 4. OneClick fallback
         if not next_delivery_date_raw and one_click:
             next_delivery_date_raw = one_click.get('NextDeliveryDate')
-        
+
         # 5. Account level final fallback
         if not next_delivery_date_raw and account_data:
             next_delivery_date_raw = account_data.get('NextDeliveryDate', '')
-        
+
         next_delivery_date = parse_date(next_delivery_date_raw)
-        
+
+        # v3.0.12: Parse payment terms days from human-readable string e.g. "Due within 1 day".
+        # Used by the payment correlation window in _calculate_cost_per_gallon() to determine
+        # whether last_payment_date is plausibly for a propane delivery vs an unrelated charge
+        # such as an annual tank rental fee. Falls back to 30 days if missing or unparseable.
+        payment_terms_str = account_data.get('PaymentTermsUpDate', '')
+        terms_match = re.search(r'\d+', str(payment_terms_str))
+        payment_terms_days = int(terms_match.group()) if terms_match else 30
+
         # Build service address
         street = account_data.get('Street', '')
         city = account_data.get('City', '')
         state_code = account_data.get('State', '')
         zip_code = account_data.get('Zip', '')
         service_address = f"{street}, {city}, {state_code} {zip_code}" if all([street, city, state_code, zip_code]) else None
-        
+
         return {
             # Tank Info
             'tank_level': safe_int(account_data.get('ForecastTankLevel'), 0),
             'tank_size': safe_int(account_data.get('TankSize'), 0),
             'days_remaining': safe_int(account_data.get('RunOutDays'), 0),
-            
+
             # Financial
             'amount_due': safe_float(account_data.get('AmounDue'), 0.0),
             'account_balance': safe_float(account_data.get('AccountBalance'), 0.0),
-            'last_payment_date': parse_date(account_data.get('LastPaymentDate')),
+            'last_payment_date': last_payment_date,
             'last_payment_amount': safe_float(account_data.get('LastPaymentAmount'), 0.0),
-            
+            'payment_terms': payment_terms_str,
+            'payment_terms_days': payment_terms_days,
+
             # Tank Monitor
             'last_tank_reading': last_tank_reading,
             'tank_monitor': 'Yes' if account_data.get('TankMonitor') == '1' else 'No',
-            
+
             # Delivery
             'last_delivery_date': last_delivery_date,
             'last_delivery_gallons': last_delivery_gallons,
             'next_delivery_date': next_delivery_date,
-            
+
             # Account Settings
             'auto_pay': account_data.get('AutoPayment', 'Unknown'),
             'paperless': account_data.get('Paperless', 'Unknown'),
             'account_number': account_data.get('ShipToAccount', 'Unknown'),
-            
+
             # Address
             'service_address': service_address,
             'street': street,
             'city': city,
             'state': state_code,
             'zip': zip_code,
-            
+
             # Metadata
             'delivery_type': account_data.get('ForecastLongName', 'Unknown'),
-            'payment_terms': account_data.get('PaymentTermsUpDate', 'Unknown'),
         }

--- a/custom_components/amerigas/config_flow.py
+++ b/custom_components/amerigas/config_flow.py
@@ -8,8 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .api import AmeriGasAPI, AmeriGasAPIError, AmeriGasAuthError
@@ -26,9 +25,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect."""
+    """Validate the user input allows us to connect.
+
+    Called from both the initial setup flow and the options flow so that
+    credential validation logic only lives in one place.
+    """
     api = AmeriGasAPI(data[CONF_USERNAME], data[CONF_PASSWORD])
-    
+
     try:
         # Attempt to fetch data to validate credentials
         await api.async_get_data()
@@ -51,10 +54,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
-        
+
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
@@ -62,7 +65,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
@@ -70,6 +73,75 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler.
+
+        v3.0.12: Enables credential updates via Settings → Devices & Services →
+        AmeriGas → Configure without requiring the integration to be deleted
+        and re-added.
+
+        Note: config_entry is NOT passed to OptionsFlow() — as of HA 2025.12,
+        config_entry is a read-only property injected by HA automatically.
+        Passing it manually and assigning self.config_entry raises AttributeError,
+        which caused the 500 Internal Server Error when opening the options flow.
+        """
+        return OptionsFlow()
+
+
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle options for AmeriGas.
+
+    v3.0.12: Allows credentials to be updated in place. The username field is
+    pre-filled with the current value; the password field is always blank so
+    the user must deliberately re-enter it (avoids storing it in form state).
+
+    HA 2025.12+: No __init__ override — config_entry is a read-only property
+    that HA injects after instantiation. Access it via self.config_entry in
+    async_step_init directly.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception in options flow")
+                errors["base"] = "unknown"
+            else:
+                # Update the config entry data with the new credentials.
+                # This takes effect on the next coordinator refresh without
+                # requiring a full HA restart.
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=user_input
+                )
+                return self.async_create_entry(title="", data={})
+
+        # Pre-fill username so the user only needs to re-enter the password
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERNAME,
+                    default=self.config_entry.data.get(CONF_USERNAME, ""),
+                ): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init", data_schema=schema, errors=errors
         )
 
 

--- a/custom_components/amerigas/manifest.json
+++ b/custom_components/amerigas/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/skircr115/ha-amerigas/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "3.0.11"
+  "version": "3.0.12"
 }

--- a/custom_components/amerigas/manifest.json
+++ b/custom_components/amerigas/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/skircr115/ha-amerigas/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "3.0.12"
+  "version": "3.1.0"
 }

--- a/custom_components/amerigas/sensor.py
+++ b/custom_components/amerigas/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfVolume,
+    UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
@@ -387,10 +388,11 @@ class AmeriGasLastPaymentDateSensor(AmeriGasSensorBase):
     
     _attr_name = "Last Payment Date"
     _attr_unique_id = "amerigas_last_payment_date"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:calendar-check"
     
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> datetime | None:
         """Return last payment date."""
         return self.coordinator.data.get("last_payment_date")
 
@@ -670,13 +672,14 @@ class PropaneEnergyConsumptionSensor(AmeriGasSensorBase):
 class PropaneDailyAverageUsageSensor(AmeriGasSensorBase):
     """Daily average usage sensor.
     
-    v3.0.7: Now uses _calculate_daily_average() which internally uses
-    _calculate_used_since_delivery() with pre-delivery level support.
+    v3.0.12: Now uses UnitOfVolumeFlowRate.GALLONS_PER_DAY and adds
+    SensorDeviceClass.VOLUME_FLOW_RATE. Also updated attribute to match.
     """
     
     _attr_name = "Daily Average Usage"
     _attr_unique_id = "propane_daily_average_usage"
-    _attr_native_unit_of_measurement = "gal/day"
+    _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_DAY
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:chart-line"
     
@@ -716,7 +719,7 @@ class PropaneDailyAverageUsageSensor(AmeriGasSensorBase):
             days = (now - last_date).days
             attrs["days_since_delivery"] = days
             if used and days > 0:
-                attrs["calculation"] = f"{used:.2f} gal ÷ {days} days = {used/days:.4f} gal/day"
+                attrs["calculation"] = f"{used:.2f} gal ÷ {days} days = {used/days:.4f} gal/d"
         
         return attrs
 

--- a/custom_components/amerigas/sensor.py
+++ b/custom_components/amerigas/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up AmeriGas sensors based on a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    
+
     # Base sensors from API
     sensors: list[SensorEntity] = [
         AmeriGasTankLevelSensor(coordinator, entry.entry_id),
@@ -64,7 +64,7 @@ async def async_setup_entry(
         AmeriGasAccountNumberSensor(coordinator, entry.entry_id),
         AmeriGasServiceAddressSensor(coordinator, entry.entry_id),
     ]
-    
+
     # Calculated sensors
     sensors.extend([
         PropaneGallonsRemainingSensor(coordinator, entry.entry_id),
@@ -79,24 +79,24 @@ async def async_setup_entry(
         PropaneDaysSinceDeliverySensor(coordinator, entry.entry_id),
         PropaneDaysRemainingDifferenceSensor(coordinator, entry.entry_id),
     ])
-    
+
     # Lifetime tracking sensors (v2.0.0+ with v2.1.0 enhancements)
     lifetime_gallons_sensor = PropaneLifetimeGallonsSensor(coordinator, hass, entry.entry_id)
     lifetime_energy_sensor = PropaneLifetimeEnergySensor(coordinator, hass, lifetime_gallons_sensor, entry.entry_id)
-    
+
     sensors.extend([
         lifetime_gallons_sensor,
         lifetime_energy_sensor,
     ])
-    
+
     async_add_entities(sensors)
 
 
 class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
     """Base class for AmeriGas sensors."""
-    
+
     _attr_has_entity_name = True
-    
+
     def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -107,28 +107,28 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
             "model": "AmeriGas Account",
         }
         self._pre_delivery_entity_id: str | None = None
-    
+
     async def async_added_to_hass(self) -> None:
         """Set up listener for pre-delivery level changes.
-        
+
         v3.0.7: All sensors that depend on usage calculations need to
         recalculate when the pre-delivery level changes, not just when
         the coordinator updates.
         """
         await super().async_added_to_hass()
-        
+
         # Find and cache the pre-delivery level entity ID
         try:
             from homeassistant.helpers import entity_registry as er
-            
+
             entity_reg = er.async_get(self.hass)
-            
+
             for entity in entity_reg.entities.values():
                 if entity.unique_id and entity.unique_id.endswith("_pre_delivery_level"):
                     if entity.platform == DOMAIN:
                         self._pre_delivery_entity_id = entity.entity_id
                         break
-            
+
             # Set up listener for pre-delivery level changes
             if self._pre_delivery_entity_id:
                 @callback
@@ -136,28 +136,28 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
                     """Handle pre-delivery level state change."""
                     if event.data.get("entity_id") != self._pre_delivery_entity_id:
                         return
-                    
+
                     new_state = event.data.get("new_state")
                     if new_state and new_state.state not in ("unknown", "unavailable"):
                         # Force recalculation of this sensor
                         self.async_write_ha_state()
-                
+
                 self.async_on_remove(
                     self.hass.bus.async_listen("state_changed", _handle_pre_delivery_change)
                 )
         except Exception as e:
             _LOGGER.debug(f"Could not set up pre-delivery level listener: {e}")
-    
+
     def _get_pre_delivery_level(self) -> float | None:
         """Get the pre-delivery level from the number entity.
-        
+
         v3.0.7: Centralized helper method for all sensors to use.
         Returns the auto-captured pre-delivery level if available,
         or None if not found or not set.
         """
         if not hasattr(self, 'hass') or self.hass is None:
             return None
-        
+
         # Use cached entity ID if available (set in async_added_to_hass)
         if hasattr(self, '_pre_delivery_entity_id') and self._pre_delivery_entity_id:
             if state := self.hass.states.get(self._pre_delivery_entity_id):
@@ -168,13 +168,13 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
                 except (ValueError, TypeError):
                     pass
             return None
-        
+
         # Fallback: search entity registry (for sensors that haven't been added to hass yet)
         try:
             from homeassistant.helpers import entity_registry as er
-            
+
             entity_reg = er.async_get(self.hass)
-            
+
             for entity in entity_reg.entities.values():
                 if entity.unique_id and entity.unique_id.endswith("_pre_delivery_level"):
                     if entity.platform == DOMAIN:
@@ -188,46 +188,46 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
                         break
         except Exception as e:
             _LOGGER.debug(f"Could not get pre-delivery level: {e}")
-        
+
         return None
-    
+
     def _calculate_gallons_remaining(self) -> float | None:
         """Calculate gallons remaining from coordinator data."""
         tank_size = self.coordinator.data.get("tank_size") or DEFAULT_TANK_SIZE
         percent = self.coordinator.data.get("tank_level") or 0
-        
+
         # Bounds check
         if percent < 0:
             percent = 0
         elif percent > 100:
             percent = 100
-        
+
         if tank_size <= 0:
             return None
-        
+
         return round(tank_size * (percent / 100), 2)
-    
+
     def _calculate_used_since_delivery(self) -> tuple[float | None, str]:
         """Calculate gallons used since delivery from coordinator data.
-        
+
         v3.0.7: Now uses auto-captured pre-delivery level if available.
         Returns tuple of (gallons_used, calculation_method).
         """
         tank_size = self.coordinator.data.get("tank_size") or DEFAULT_TANK_SIZE
         tank_level = self.coordinator.data.get("tank_level") or 0
-        
+
         # Bounds check
         if tank_level < 0:
             tank_level = 0
         elif tank_level > 100:
             tank_level = 100
-        
+
         current = tank_size * (tank_level / 100)
         last_delivery = self.coordinator.data.get("last_delivery_gallons") or 0
-        
+
         # v3.0.7: Check for auto-captured pre-delivery level
         pre_delivery_level = self._get_pre_delivery_level()
-        
+
         if pre_delivery_level and pre_delivery_level > 0:
             # Use auto-captured level (100% accurate)
             starting_level = pre_delivery_level + last_delivery
@@ -245,34 +245,34 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
             # Fallback: assume 80% fill
             starting_level = tank_size * DEFAULT_FILL_PERCENTAGE
             calculation_method = "assumed_80_percent"
-        
+
         # Cap at tank capacity
         if starting_level > tank_size:
             starting_level = tank_size
-        
+
         used = starting_level - current
-        
+
         return (max(0, round(used, 2)), calculation_method)
-    
+
     def _calculate_daily_average(self) -> float | None:
         """Calculate daily average usage from coordinator data.
-        
+
         v3.0.7: Now uses _calculate_used_since_delivery which includes pre-delivery level.
         """
         last_date = self.coordinator.data.get("last_delivery_date")
         if not last_date:
             return None
-        
+
         used, _ = self._calculate_used_since_delivery()
         if used is None:
             return None
-        
+
         now = dt_util.now()
         days = (now - last_date).days
-        
+
         if days <= 0:
             return None
-        
+
         return round(used / days, 2)
     
     def _calculate_cost_per_gallon(self) -> float | None:
@@ -292,18 +292,18 @@ class AmeriGasSensorBase(CoordinatorEntity, SensorEntity):
 
 class AmeriGasTankLevelSensor(AmeriGasSensorBase):
     """Tank level percentage sensor."""
-    
+
     _attr_name = "Tank Level"
     _attr_unique_id = "amerigas_tank_level"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:propane-tank"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return tank level percentage."""
         return self.coordinator.data.get("tank_level")
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
@@ -315,14 +315,14 @@ class AmeriGasTankLevelSensor(AmeriGasSensorBase):
 
 class AmeriGasTankSizeSensor(AmeriGasSensorBase):
     """Tank size sensor."""
-    
+
     _attr_name = "Tank Size"
     _attr_unique_id = "amerigas_tank_size"
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:propane-tank-outline"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return tank size."""
@@ -331,13 +331,13 @@ class AmeriGasTankSizeSensor(AmeriGasSensorBase):
 
 class AmeriGasDaysRemainingSensor(AmeriGasSensorBase):
     """Days remaining sensor (AmeriGas estimate)."""
-    
+
     _attr_name = "Days Remaining (AmeriGas)"
     _attr_unique_id = "amerigas_days_remaining"
     _attr_native_unit_of_measurement = "days"
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:calendar-clock"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return days remaining."""
@@ -346,37 +346,39 @@ class AmeriGasDaysRemainingSensor(AmeriGasSensorBase):
 
 class AmeriGasAmountDueSensor(AmeriGasSensorBase):
     """Amount due sensor."""
-    
+
     _attr_name = "Amount Due"
     _attr_unique_id = "amerigas_amount_due"
     _attr_native_unit_of_measurement = "USD"
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = "mdi:currency-usd"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return amount due."""
         return self.coordinator.data.get("amount_due")
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         return {
             "payment_terms": self.coordinator.data.get("payment_terms"),
+            # v3.0.12: expose parsed integer alongside the raw string
+            "payment_terms_days": self.coordinator.data.get("payment_terms_days"),
         }
 
 
 class AmeriGasAccountBalanceSensor(AmeriGasSensorBase):
     """Account balance sensor."""
-    
+
     _attr_name = "Account Balance"
     _attr_unique_id = "amerigas_account_balance"
     _attr_native_unit_of_measurement = "USD"
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = "mdi:cash"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return account balance."""
@@ -385,12 +387,12 @@ class AmeriGasAccountBalanceSensor(AmeriGasSensorBase):
 
 class AmeriGasLastPaymentDateSensor(AmeriGasSensorBase):
     """Last payment date sensor."""
-    
+
     _attr_name = "Last Payment Date"
     _attr_unique_id = "amerigas_last_payment_date"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:calendar-check"
-    
+
     @property
     def native_value(self) -> datetime | None:
         """Return last payment date."""
@@ -399,13 +401,13 @@ class AmeriGasLastPaymentDateSensor(AmeriGasSensorBase):
 
 class AmeriGasLastPaymentAmountSensor(AmeriGasSensorBase):
     """Last payment amount sensor."""
-    
+
     _attr_name = "Last Payment Amount"
     _attr_unique_id = "amerigas_last_payment_amount"
     _attr_native_unit_of_measurement = "USD"
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:credit-card"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return last payment amount."""
@@ -414,12 +416,12 @@ class AmeriGasLastPaymentAmountSensor(AmeriGasSensorBase):
 
 class AmeriGasLastTankReadingSensor(AmeriGasSensorBase):
     """Last tank reading timestamp sensor."""
-    
+
     _attr_name = "Last Tank Reading"
     _attr_unique_id = "amerigas_last_tank_reading"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:clock-outline"
-    
+
     @property
     def native_value(self) -> datetime | None:
         """Return last tank reading timestamp."""
@@ -428,12 +430,12 @@ class AmeriGasLastTankReadingSensor(AmeriGasSensorBase):
 
 class AmeriGasLastDeliveryDateSensor(AmeriGasSensorBase):
     """Last delivery date sensor."""
-    
+
     _attr_name = "Last Delivery Date"
     _attr_unique_id = "amerigas_last_delivery_date"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:truck-delivery"
-    
+
     @property
     def native_value(self) -> datetime | None:
         """Return last delivery date."""
@@ -442,13 +444,13 @@ class AmeriGasLastDeliveryDateSensor(AmeriGasSensorBase):
 
 class AmeriGasLastDeliveryGallonsSensor(AmeriGasSensorBase):
     """Last delivery gallons sensor."""
-    
+
     _attr_name = "Last Delivery Gallons"
     _attr_unique_id = "amerigas_last_delivery_gallons"
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:gas-station"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return last delivery gallons."""
@@ -457,17 +459,17 @@ class AmeriGasLastDeliveryGallonsSensor(AmeriGasSensorBase):
 
 class AmeriGasNextDeliveryDateSensor(AmeriGasSensorBase):
     """Next delivery date sensor."""
-    
+
     _attr_name = "Next Delivery Date"
     _attr_unique_id = "amerigas_next_delivery_date"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:truck-delivery"
-    
+
     @property
     def native_value(self) -> datetime | None:
         """Return next delivery date."""
         return self.coordinator.data.get("next_delivery_date")
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
@@ -479,12 +481,12 @@ class AmeriGasNextDeliveryDateSensor(AmeriGasSensorBase):
 
 class AmeriGasAutoPaySensor(AmeriGasSensorBase):
     """Auto pay status sensor."""
-    
+
     _attr_name = "Auto Pay"
     _attr_unique_id = "amerigas_auto_pay"
     _attr_icon = "mdi:credit-card-check"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    
+
     @property
     def native_value(self) -> str | None:
         """Return auto pay status."""
@@ -493,12 +495,12 @@ class AmeriGasAutoPaySensor(AmeriGasSensorBase):
 
 class AmeriGasPaperlessSensor(AmeriGasSensorBase):
     """Paperless billing status sensor."""
-    
+
     _attr_name = "Paperless Billing"
     _attr_unique_id = "amerigas_paperless"
     _attr_icon = "mdi:file-document"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    
+
     @property
     def native_value(self) -> str | None:
         """Return paperless billing status."""
@@ -507,12 +509,12 @@ class AmeriGasPaperlessSensor(AmeriGasSensorBase):
 
 class AmeriGasAccountNumberSensor(AmeriGasSensorBase):
     """Account number sensor."""
-    
+
     _attr_name = "Account Number"
     _attr_unique_id = "amerigas_account_number"
     _attr_icon = "mdi:account"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    
+
     @property
     def native_value(self) -> str | None:
         """Return account number."""
@@ -521,17 +523,17 @@ class AmeriGasAccountNumberSensor(AmeriGasSensorBase):
 
 class AmeriGasServiceAddressSensor(AmeriGasSensorBase):
     """Service address sensor."""
-    
+
     _attr_name = "Service Address"
     _attr_unique_id = "amerigas_service_address"
     _attr_icon = "mdi:home-map-marker"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    
+
     @property
     def native_value(self) -> str | None:
         """Return service address."""
         return self.coordinator.data.get("service_address")
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
@@ -549,18 +551,18 @@ class AmeriGasServiceAddressSensor(AmeriGasSensorBase):
 
 class PropaneGallonsRemainingSensor(AmeriGasSensorBase):
     """Gallons remaining sensor with v2.0.1 bounds checking."""
-    
+
     _attr_name = "Gallons Remaining"
     _attr_unique_id = "propane_tank_gallons_remaining"
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    
+
     @property
     def native_value(self) -> float | None:
         """Return gallons remaining with bounds checking."""
         return self._calculate_gallons_remaining()
-    
+
     @property
     def available(self) -> bool:
         """Return if sensor is available."""
@@ -570,34 +572,34 @@ class PropaneGallonsRemainingSensor(AmeriGasSensorBase):
 
 class PropaneUsedSinceDeliverySensor(AmeriGasSensorBase):
     """Used since delivery sensor with v3.0.7 improvements.
-    
+
     v3.0.7: Now uses the centralized _calculate_used_since_delivery() helper
     which properly looks up the pre-delivery level.
     """
-    
+
     _attr_name = "Used Since Last Delivery"
     _attr_unique_id = "propane_used_since_last_delivery"
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = "mdi:gas-station"
-    
+
     def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, entry_id)
         self._calculation_method = "unknown"
         self._starting_level = 0.0
-    
+
     @property
     def native_value(self) -> float | None:
         """Return gallons used with auto-captured pre-delivery level."""
         used, method = self._calculate_used_since_delivery()
         self._calculation_method = method
-        
+
         # Calculate starting level for attributes
         pre_delivery = self._get_pre_delivery_level()
         last_delivery = self.coordinator.data.get("last_delivery_gallons") or 0
         tank_size = self.coordinator.data.get("tank_size") or DEFAULT_TANK_SIZE
-        
+
         if pre_delivery and pre_delivery > 0:
             self._starting_level = min(pre_delivery + last_delivery, tank_size)
         elif last_delivery > 0:
@@ -608,21 +610,21 @@ class PropaneUsedSinceDeliverySensor(AmeriGasSensorBase):
             self._starting_level = min(estimated_before + last_delivery, tank_size)
         else:
             self._starting_level = tank_size * DEFAULT_FILL_PERCENTAGE
-        
+
         return used
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         last_delivery = self.coordinator.data.get("last_delivery_gallons") or 0
         pre_delivery = self._get_pre_delivery_level()
-        
+
         attrs = {
             "calculation_method": self._calculation_method,
             "last_delivery_gallons": last_delivery,
             "calculated_starting_level": round(self._starting_level, 2),
         }
-        
+
         if pre_delivery and pre_delivery > 0:
             attrs["pre_delivery_level"] = round(pre_delivery, 2)
             attrs["accuracy"] = "100% (auto-captured)"
@@ -632,36 +634,36 @@ class PropaneUsedSinceDeliverySensor(AmeriGasSensorBase):
             attrs["accuracy"] = "~95% (estimated)"
         else:
             attrs["accuracy"] = "~90% (estimated)"
-        
+
         return attrs
 
 
 class PropaneEnergyConsumptionSensor(AmeriGasSensorBase):
     """Energy consumption sensor (display only, not for Energy Dashboard).
-    
+
     v3.0.7: Now uses _calculate_used_since_delivery() which includes pre-delivery level.
     """
-    
+
     _attr_name = "Energy Consumption (Display)"
     _attr_unique_id = "propane_energy_consumption"
     _attr_native_unit_of_measurement = "ft³"
     _attr_device_class = SensorDeviceClass.GAS
     _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = "mdi:fire"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return energy in cubic feet.
-        
+
         v3.0.7: Uses centralized helper that includes pre-delivery level.
         """
         used, _ = self._calculate_used_since_delivery()
-        
+
         if used is None:
             return None
-        
+
         return round(used * GALLONS_TO_CUBIC_FEET, 2)
-    
+
     @property
     def available(self) -> bool:
         """Return availability."""
@@ -671,125 +673,130 @@ class PropaneEnergyConsumptionSensor(AmeriGasSensorBase):
 
 class PropaneDailyAverageUsageSensor(AmeriGasSensorBase):
     """Daily average usage sensor.
-    
-    v3.0.12: Now uses UnitOfVolumeFlowRate.GALLONS_PER_DAY and adds
-    SensorDeviceClass.VOLUME_FLOW_RATE. Also updated attribute to match.
+
+    v3.0.7: Now uses _calculate_daily_average() which internally uses
+    _calculate_used_since_delivery() with pre-delivery level support.
+
+    v3.0.12: Uses UnitOfVolumeFlowRate.GALLONS_PER_DAY ("gal/d") and adds
+    SensorDeviceClass.VOLUME_FLOW_RATE for proper HA unit handling. Existing
+    installs will receive a one-time statistics unit-change prompt in
+    Developer Tools → Statistics; accepting it is safe and expected.
     """
-    
+
     _attr_name = "Daily Average Usage"
     _attr_unique_id = "propane_daily_average_usage"
     _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_DAY
     _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:chart-line"
-    
+
     @property
     def native_value(self) -> float | None:
         """Return daily average usage.
-        
+
         v3.0.7: Uses centralized helper that includes pre-delivery level.
         """
         return self._calculate_daily_average()
-    
+
     @property
     def available(self) -> bool:
         """Return availability."""
         last_date = self.coordinator.data.get("last_delivery_date")
         if not last_date:
             return False
-        
+
         now = dt_util.now()
         days = (now - last_date).days
         tank_size = self.coordinator.data.get("tank_size")
         return days > 0 and tank_size and tank_size > 0
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         last_date = self.coordinator.data.get("last_delivery_date")
         used, method = self._calculate_used_since_delivery()
-        
+
         attrs = {
             "calculation_method": method,
             "gallons_used": used,
         }
-        
+
         if last_date:
             now = dt_util.now()
             days = (now - last_date).days
             attrs["days_since_delivery"] = days
             if used and days > 0:
                 attrs["calculation"] = f"{used:.2f} gal ÷ {days} days = {used/days:.4f} gal/d"
-        
+
         return attrs
 
 
 class PropaneDaysUntilEmptySensor(AmeriGasSensorBase):
     """Days until empty sensor.
-    
+
     v3.0.7: Uses _calculate_daily_average() which now includes pre-delivery level.
     """
-    
+
     _attr_name = "Days Until Empty"
     _attr_unique_id = "propane_days_until_empty"
     _attr_native_unit_of_measurement = "days"
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:calendar-clock"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return days until empty."""
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
-        
+
         if remaining is None or avg_usage is None:
             return None
-        
+
         if remaining <= 0:
             return 0
-        
+
         if avg_usage < 0.001:
             return 9999
-        
+
         days = remaining / avg_usage
-        
+
         if days > 9999:
             return 9999
-        
+
         return round(days)
-    
+
     @property
     def available(self) -> bool:
         """Sensor is available if we have the data needed to calculate."""
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
         return remaining is not None and avg_usage is not None
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
         _, method = self._calculate_used_since_delivery()
-        
+
         attrs = {
             "gallons_remaining": remaining,
             "daily_average_usage": avg_usage,
             "calculation_method": method,
         }
-        
+
         if avg_usage is not None:
             if avg_usage < 0.001:
                 attrs["note"] = "Usage rate extremely low - showing 9999 days as practical maximum"
             elif avg_usage < 0.1:
-                attrs["note"] = f"Low usage rate: {avg_usage:.3f} gal/day"
-        
+                attrs["note"] = f"Low usage rate: {avg_usage:.3f} gal/d"
+
         if remaining is not None and avg_usage is not None and avg_usage > 0:
             days_raw = remaining / avg_usage
-            attrs["calculation"] = f"{remaining:.2f} gal ÷ {avg_usage:.2f} gal/day = {days_raw:.1f} days"
+            attrs["calculation"] = f"{remaining:.2f} gal ÷ {avg_usage:.2f} gal/d = {days_raw:.1f} days"
             if days_raw > 9999:
                 attrs["calculation"] += " (capped at 9999)"
-        
+
         return attrs
 
 
@@ -842,10 +849,10 @@ class PropaneCostPerCubicFootSensor(AmeriGasSensorBase):
 
 class PropaneCostSinceDeliverySensor(AmeriGasSensorBase):
     """Cost since delivery sensor.
-    
+
     v3.0.7: Uses centralized _calculate_used_since_delivery() helper.
     """
-    
+
     _attr_name = "Cost Since Last Delivery"
     _attr_unique_id = "propane_cost_since_last_delivery"
     _attr_native_unit_of_measurement = "USD"
@@ -891,10 +898,10 @@ class PropaneCostSinceDeliverySensor(AmeriGasSensorBase):
 
 class PropaneEstimatedRefillCostSensor(AmeriGasSensorBase):
     """Estimated refill cost sensor.
-    
+
     v3.0.7: Uses centralized helpers for consistent calculations.
     """
-    
+
     _attr_name = "Estimated Refill Cost"
     _attr_unique_id = "propane_estimated_refill_cost"
     _attr_native_unit_of_measurement = "USD"
@@ -910,10 +917,10 @@ class PropaneEstimatedRefillCostSensor(AmeriGasSensorBase):
         
         if remaining is None or cost is None:
             return None
-        
+
         max_fill_level = tank_size * 0.80
         needed = max_fill_level - remaining
-        
+
         if needed < 0:
             needed = 0
         elif needed > tank_size:
@@ -926,12 +933,12 @@ class PropaneEstimatedRefillCostSensor(AmeriGasSensorBase):
         """Return extra attributes."""
         tank_size = self.coordinator.data.get("tank_size") or DEFAULT_TANK_SIZE
         remaining = self._calculate_gallons_remaining()
-        
+
         max_fill_level = tank_size * 0.80
         needed = max_fill_level - remaining if remaining else 0
         if needed < 0:
             needed = 0
-        
+
         return {
             "max_fill_level": round(max_fill_level, 2),
             "gallons_needed": round(needed, 2),
@@ -942,23 +949,23 @@ class PropaneEstimatedRefillCostSensor(AmeriGasSensorBase):
 
 class PropaneDaysSinceDeliverySensor(AmeriGasSensorBase):
     """Days since delivery sensor."""
-    
+
     _attr_name = "Days Since Last Delivery"
     _attr_unique_id = "propane_days_since_last_delivery"
     _attr_native_unit_of_measurement = "days"
     _attr_icon = "mdi:calendar"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return days since delivery."""
         last_date = self.coordinator.data.get("last_delivery_date")
-        
+
         if not last_date:
             return None
-        
+
         now = dt_util.now()
         return (now - last_date).days
-    
+
     @property
     def available(self) -> bool:
         """Return availability."""
@@ -967,26 +974,26 @@ class PropaneDaysSinceDeliverySensor(AmeriGasSensorBase):
 
 class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
     """Days remaining difference sensor.
-    
+
     v3.0.7: Uses centralized helpers for consistent calculations.
     """
-    
+
     _attr_name = "Days Remaining Difference"
     _attr_unique_id = "propane_days_remaining_difference"
     _attr_native_unit_of_measurement = "days"
     _attr_icon = "mdi:compare"
-    
+
     @property
     def native_value(self) -> int | None:
         """Return difference in estimates."""
         amerigas = self.coordinator.data.get("days_remaining") or 0
-        
+
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
-        
+
         if remaining is None or avg_usage is None:
             return None
-        
+
         if remaining <= 0:
             mine = 0
         elif avg_usage < 0.001:
@@ -994,9 +1001,9 @@ class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
         else:
             days = remaining / avg_usage
             mine = min(round(days), 9999)
-        
+
         return mine - amerigas
-    
+
     @property
     def available(self) -> bool:
         """Available if we have data to calculate."""
@@ -1004,14 +1011,14 @@ class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
         return amerigas is not None and remaining is not None and avg_usage is not None
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         remaining = self._calculate_gallons_remaining()
         avg_usage = self._calculate_daily_average()
         _, method = self._calculate_used_since_delivery()
-        
+
         mine = None
         if remaining is not None and avg_usage is not None:
             if remaining <= 0:
@@ -1021,7 +1028,7 @@ class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
             else:
                 days = remaining / avg_usage
                 mine = min(round(days), 9999)
-        
+
         attrs = {
             "amerigas_estimate": self.coordinator.data.get("days_remaining"),
             "your_estimate": mine,
@@ -1029,16 +1036,16 @@ class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
             "daily_average_usage": avg_usage,
             "calculation_method": method,
         }
-        
+
         if remaining is not None and avg_usage is not None and avg_usage > 0:
             days_raw = remaining / avg_usage
-            attrs["calculation"] = f"{remaining:.2f} gal ÷ {avg_usage:.2f} gal/day = {days_raw:.1f} days"
+            attrs["calculation"] = f"{remaining:.2f} gal ÷ {avg_usage:.2f} gal/d = {days_raw:.1f} days"
             if days_raw > 9999:
                 attrs["calculation"] += " (capped at 9999)"
-        
+
         if avg_usage is not None and avg_usage < 0.001:
             attrs["note"] = "Usage rate extremely low - estimate capped at 9999 days"
-        
+
         return attrs
 
 
@@ -1048,18 +1055,18 @@ class PropaneDaysRemainingDifferenceSensor(AmeriGasSensorBase):
 
 class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
     """Lifetime gallons sensor with robust state restoration.
-    
+
     v3.0.8 FIX: Added _restoration_complete flag to prevent race condition
     where coordinator updates could happen before state restoration finishes,
     causing the sensor to reset to 0 and corrupt Energy Dashboard data.
     """
-    
+
     _attr_name = "Lifetime Gallons"
     _attr_unique_id = "propane_lifetime_gallons"
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:gas-station"
-    
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass: HomeAssistant, entry_id: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, entry_id)
@@ -1070,16 +1077,16 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
         self._ignored_triggers: int = 0
         self._largest_consumption: float = 0.0
         self._restoration_complete: bool = False  # v3.0.8: Prevent updates before restoration
-    
+
     async def async_added_to_hass(self) -> None:
         """Restore state when added to hass.
-        
+
         v3.0.8: State restoration MUST complete before any coordinator updates
         are processed, otherwise we risk overwriting the database with 0.0 and
         corrupting Energy Dashboard historical data.
         """
         await super().async_added_to_hass()
-        
+
         if (last_state := await self.async_get_last_state()) is not None:
             if last_state.state not in (None, "", "unknown", "unavailable"):
                 try:
@@ -1089,47 +1096,47 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
                         _LOGGER.info(f"Restored lifetime gallons: {self._lifetime_total}")
                 except (ValueError, TypeError) as e:
                     _LOGGER.warning(f"Could not restore lifetime gallons: {e}")
-            
+
             if last_state.attributes:
                 try:
                     if "previous_gallons" in last_state.attributes:
                         self._previous_gallons = float(last_state.attributes["previous_gallons"])
-                    
+
                     last_event = last_state.attributes.get("last_consumption_event")
                     if last_event and last_event != "never":
                         try:
                             self._last_consumption_event = datetime.fromisoformat(last_event)
                         except (ValueError, TypeError):
                             self._last_consumption_event = None
-                    
+
                     self._total_triggers = last_state.attributes.get("total_triggers", 0)
                     self._ignored_triggers = last_state.attributes.get("ignored_triggers", 0)
                     self._largest_consumption = last_state.attributes.get("largest_consumption", 0.0)
-                    
+
                     if self._lifetime_total == 0.0 and "last_valid_state" in last_state.attributes:
                         backup = last_state.attributes.get("last_valid_state")
                         if backup and backup > 0:
                             self._lifetime_total = float(backup)
                             _LOGGER.warning(f"Main state was 0, restored from backup: {self._lifetime_total}")
-                
+
                 except Exception as e:
                     _LOGGER.error(f"Error restoring lifetime sensor attributes: {e}")
-        
+
         # v3.0.8 FIX: Mark restoration complete BEFORE adding listener
         self._restoration_complete = True
         _LOGGER.debug(f"State restoration complete. Lifetime total: {self._lifetime_total} gal")
-        
+
         self.async_on_remove(
             self.coordinator.async_add_listener(self._handle_coordinator_update)
         )
-        
+
         if self.coordinator.last_update_success and self.coordinator.data:
             self._handle_coordinator_update()
-    
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
-        
+
         v3.0.8 FIX: Block all updates until restoration completes.
         This prevents writing 0.0 to database during startup which would
         corrupt Energy Dashboard historical data permanently.
@@ -1138,22 +1145,22 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
         if not self._restoration_complete:
             _LOGGER.debug("Skipping update - state restoration not complete")
             return
-        
+
         current_gallons = self._calculate_gallons_remaining()
         if current_gallons is None:
             # v3.0.8: Preserve existing value when API unreachable
             _LOGGER.debug("API unreachable - preserving existing lifetime total")
             self.async_write_ha_state()
             return
-        
+
         if self._previous_gallons is None:
             self._previous_gallons = current_gallons
             self.async_write_ha_state()
             return
-        
+
         diff = self._previous_gallons - current_gallons
         self._total_triggers += 1
-        
+
         if diff > NOISE_THRESHOLD_GALLONS:
             self._lifetime_total += diff
             self._previous_gallons = current_gallons
@@ -1167,14 +1174,14 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
             if diff < -1.0:
                 _LOGGER.info(f"Delivery detected: +{abs(diff):.2f} gal")
             self._previous_gallons = current_gallons
-        
+
         self.async_write_ha_state()
-    
+
     @property
     def native_value(self) -> float:
         """Return lifetime gallons."""
         return round(self._lifetime_total, 2)
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
@@ -1184,7 +1191,7 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
             last_event = self._last_consumption_event
         else:
             last_event = self._last_consumption_event.isoformat()
-        
+
         return {
             "last_valid_state": self._lifetime_total,
             "previous_gallons": self._previous_gallons if self._previous_gallons is not None else 0.0,
@@ -1194,50 +1201,50 @@ class PropaneLifetimeGallonsSensor(AmeriGasSensorBase, RestoreEntity):
             "largest_consumption": round(self._largest_consumption, 2),
             "threshold_gallons": NOISE_THRESHOLD_GALLONS,
             "restoration_complete": self._restoration_complete,  # v3.0.8: Debug aid
-            "version": "3.0.8",
+            "version": "3.0.12",
         }
 
 
 class PropaneLifetimeEnergySensor(AmeriGasSensorBase):
     """Lifetime energy sensor for Energy Dashboard."""
-    
+
     _attr_name = "Lifetime Energy"
     _attr_unique_id = "propane_lifetime_energy"
     _attr_native_unit_of_measurement = "ft³"
     _attr_device_class = SensorDeviceClass.GAS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:fire"
-    
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass: HomeAssistant, lifetime_gallons_sensor: PropaneLifetimeGallonsSensor, entry_id: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, entry_id)
         self._hass = hass
         self._lifetime_gallons_sensor = lifetime_gallons_sensor
-    
+
     @property
     def native_value(self) -> float:
         """Return lifetime energy in cubic feet."""
         gallons = self._lifetime_gallons_sensor.native_value
-        
+
         if gallons is None or gallons == 0:
             return 0.0
-        
+
         return round(gallons * GALLONS_TO_CUBIC_FEET, 2)
-    
+
     @property
     def available(self) -> bool:
         """Always available, even if value is 0."""
         return True
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         gallons = self._lifetime_gallons_sensor.native_value
-        
+
         return {
             "source_sensor": "sensor.propane_tank_lifetime_gallons",
             "conversion_factor": GALLONS_TO_CUBIC_FEET,
             "lifetime_gallons": gallons if gallons is not None else 0.0,
             "formula": f"{gallons if gallons else 0.0} gal × {GALLONS_TO_CUBIC_FEET} ft³/gal",
-            "version": "3.0.8",
+            "version": "3.0.12",
         }

--- a/custom_components/amerigas/strings.json
+++ b/custom_components/amerigas/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up AmeriGas Propane",
-        "description": "Enter your MyAmeriGas account credentials",
+        "title": "AmeriGas Propane",
+        "description": "Enter your AmeriGas account credentials.",
         "data": {
           "username": "Email Address",
           "password": "Password"
@@ -19,7 +19,24 @@
       "already_configured": "This account is already configured."
     }
   },
-  "services": {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update AmeriGas Credentials",
+        "description": "Update your AmeriGas account credentials. Enter your username and re-enter your password.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to AmeriGas. Please try again.",
+      "invalid_auth": "Invalid email address or password.",
+      "unknown": "Unexpected error. Check the Home Assistant logs for details."
+    }
+  },
+    "services": {
     "set_pre_delivery_level": {
       "name": "Set Pre-Delivery Level",
       "description": "Manually set the pre-delivery tank level for accurate consumption tracking.",

--- a/custom_components/amerigas/translations/en.json
+++ b/custom_components/amerigas/translations/en.json
@@ -1,0 +1,39 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "AmeriGas Propane",
+        "description": "Enter your AmeriGas account credentials.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to AmeriGas. Please try again.",
+      "invalid_auth": "Invalid email address or password.",
+      "unknown": "Unexpected error. Check the Home Assistant logs for details."
+    },
+    "abort": {
+      "already_configured": "AmeriGas account is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update AmeriGas Credentials",
+        "description": "Update your AmeriGas account credentials. Enter your username and re-enter your password.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to AmeriGas. Please try again.",
+      "invalid_auth": "Invalid email address or password.",
+      "unknown": "Unexpected error. Check the Home Assistant logs for details."
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -4,6 +4,6 @@
     "US"
   ],
   "render_readme": true,
-  "homeassistant": "2024.1.0",
+  "homeassistant": "2026.1.0",
   "hacs": "1.6.0"
 }


### PR DESCRIPTION
## Description
# AmeriGas Propane v3.1.0

## What's New

### 🔐 Update Credentials Without Reinstalling

You can now change your AmeriGas password (or username) directly from the integration — no need to delete and re-add it.

**Settings → Devices & Services → AmeriGas → Configure**

Enter your updated credentials, and they'll be validated and applied on the next data refresh. No restart required, and your historical data and Energy Dashboard statistics are fully preserved.

---

### 📊 Daily Average Usage — Correct Unit & Device Class

`sensor.propane_daily_average_usage` now uses `gal/d` with `SensorDeviceClass.VOLUME_FLOW_RATE`, which is the correct Home Assistant representation for a consumption rate. Previously the sensor used a plain string unit with no device class, causing inconsistent display in the UI.

> **Existing users:** Home Assistant will show a one-time unit-change prompt under **Developer Tools → Statistics** for this sensor. Accept it — it corrects the historical unit metadata without changing any recorded values.

---

### 💳 Payment Date & Terms Improvements

- `sensor.amerigas_last_payment_date` now returns a fully timezone-aware `datetime` consistent with all other date sensors, fixing potential display issues for non-UTC timezones.
- `sensor.amerigas_amount_due` gains a `payment_terms_days` attribute (integer) parsed from the payment terms string — useful for automations like "alert me if I owe money and payment is due within 3 days."

---

## Upgrading

Update via HACS and restart. No breaking changes — all existing sensors, entity IDs, automations, and Energy Dashboard configuration continue working without modification.

If you see a Statistics unit-change prompt for `propane_daily_average_usage`, accept it. That's the only action required.

---

## Full Changelog

See [[CHANGELOG.md](https://github.com/skircr115/ha-amerigas/blob/main/CHANGELOG.md)](https://github.com/skircr115/ha-amerigas/blob/main/CHANGELOG.md) for the complete history.

**Previous release:** [[v3.0.11](https://github.com/skircr115/ha-amerigas/releases/tag/v3.0.11)](https://github.com/skircr115/ha-amerigas/releases/tag/v3.0.11) — Date timezone fix for US timezones and next delivery date entity disappearing.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Testing
- [X] Tested in development environment
- [X] All sensors work correctly
- [X] No errors in logs
- [X] Automations tested (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-review of code completed
- [X] Comments added for complex code
- [X] Documentation updated
- [X] No breaking changes (or documented)
- [X] Commit messages follow guidelines

## Related Issues
Fixes #15 
Relates to #22 (not fixed as of yet, but adds partial framework)