### PR TITLE
Fix: Correct Service Address and Delivery Address discrepancies

### DIFF
--- a/custom_components/amerigas/api.py
+++ b/custom_components/amerigas/api.py
@@ -235,12 +235,12 @@ class AmeriGasAPI:
         terms_match = re.search(r'\d+', str(payment_terms_str))
         payment_terms_days = int(terms_match.group()) if terms_match else 30
 
-        # Build service address
+        # Build delivery address
         street = account_data.get('Street', '')
         city = account_data.get('City', '')
         state_code = account_data.get('State', '')
         zip_code = account_data.get('Zip', '')
-        service_address = f"{street}, {city}, {state_code} {zip_code}" if all([street, city, state_code, zip_code]) else None
+        delivery_address = f"{street}, {city}, {state_code} {zip_code}" if all([street, city, state_code, zip_code]) else None
 
         return {
             # Tank Info
@@ -271,7 +271,7 @@ class AmeriGasAPI:
             'account_number': account_data.get('ShipToAccount', 'Unknown'),
 
             # Address
-            'service_address': service_address,
+            'delivery_address': delivery_address,
             'street': street,
             'city': city,
             'state': state_code,

--- a/custom_components/amerigas/api.py
+++ b/custom_components/amerigas/api.py
@@ -119,7 +119,14 @@ class AmeriGasAPI:
         if not match:
             raise AmeriGasAPIError("Could not find accountSummaryViewModel in page")
 
-        return json.loads(match.group(1))
+        account_data = json.loads(match.group(1))
+
+        # Also extract the HTML-rendered Delivery Address which is explicitly separate from the Street field in some cases
+        delivery_address_match = re.search(r'Delivery Address:.*?<span>(.*?)</span>', dashboard_text, re.DOTALL | re.IGNORECASE)
+        if delivery_address_match:
+            account_data['DeliveryAddressHTML'] = delivery_address_match.group(1).strip()
+
+        return account_data
 
     def _parse_account_data(self, account_data: dict[str, Any]) -> dict[str, Any]:
         """Parse raw account data into clean format."""
@@ -235,12 +242,15 @@ class AmeriGasAPI:
         terms_match = re.search(r'\d+', str(payment_terms_str))
         payment_terms_days = int(terms_match.group()) if terms_match else 30
 
-        # Build delivery address
+        # Build service address
         street = account_data.get('Street', '')
         city = account_data.get('City', '')
         state_code = account_data.get('State', '')
         zip_code = account_data.get('Zip', '')
-        delivery_address = f"{street}, {city}, {state_code} {zip_code}" if all([street, city, state_code, zip_code]) else None
+        service_address = f"{street}, {city}, {state_code} {zip_code}" if all([street, city, state_code, zip_code]) else None
+
+        # Delivery address is explicitly rendered in the HTML for some customers where "service address" is their billing address
+        delivery_address = account_data.get('DeliveryAddressHTML', service_address)
 
         return {
             # Tank Info
@@ -271,6 +281,7 @@ class AmeriGasAPI:
             'account_number': account_data.get('ShipToAccount', 'Unknown'),
 
             # Address
+            'service_address': service_address,
             'delivery_address': delivery_address,
             'street': street,
             'city': city,

--- a/custom_components/amerigas/const.py
+++ b/custom_components/amerigas/const.py
@@ -27,7 +27,7 @@ NEXT_DELIVERY_DATE: Final = "next_delivery_date"
 AUTO_PAY: Final = "auto_pay"
 PAPERLESS: Final = "paperless"
 ACCOUNT_NUMBER: Final = "account_number"
-SERVICE_ADDRESS: Final = "service_address"
+DELIVERY_ADDRESS: Final = "delivery_address"
 
 # Calculated Sensor Keys
 GALLONS_REMAINING: Final = "gallons_remaining"

--- a/custom_components/amerigas/const.py
+++ b/custom_components/amerigas/const.py
@@ -27,6 +27,7 @@ NEXT_DELIVERY_DATE: Final = "next_delivery_date"
 AUTO_PAY: Final = "auto_pay"
 PAPERLESS: Final = "paperless"
 ACCOUNT_NUMBER: Final = "account_number"
+SERVICE_ADDRESS: Final = "service_address"
 DELIVERY_ADDRESS: Final = "delivery_address"
 
 # Calculated Sensor Keys

--- a/custom_components/amerigas/sensor.py
+++ b/custom_components/amerigas/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    Platform,
     UnitOfEnergy,
     UnitOfVolume,
     UnitOfVolumeFlowRate,
@@ -44,6 +45,21 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AmeriGas sensors based on a config entry."""
+    from homeassistant.helpers import entity_registry as er
+
+    # Migrate old service_address sensor to delivery_address
+    entity_reg = er.async_get(hass)
+
+    # Try both with and without entry_id prefix in case the integration ever used either
+    for old_unique_id, new_unique_id in [
+        ("amerigas_service_address", "amerigas_delivery_address"),
+        (f"{entry.entry_id}_amerigas_service_address", f"{entry.entry_id}_amerigas_delivery_address")
+    ]:
+        old_entity_id = entity_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, old_unique_id)
+        if old_entity_id:
+            _LOGGER.debug(f"Migrating AmeriGas sensor unique_id from {old_unique_id} to {new_unique_id}")
+            entity_reg.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
+
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     # Base sensors from API
@@ -62,7 +78,7 @@ async def async_setup_entry(
         AmeriGasAutoPaySensor(coordinator, entry.entry_id),
         AmeriGasPaperlessSensor(coordinator, entry.entry_id),
         AmeriGasAccountNumberSensor(coordinator, entry.entry_id),
-        AmeriGasServiceAddressSensor(coordinator, entry.entry_id),
+        AmeriGasDeliveryAddressSensor(coordinator, entry.entry_id),
     ]
 
     # Calculated sensors
@@ -589,18 +605,18 @@ class AmeriGasAccountNumberSensor(AmeriGasSensorBase):
         return self.coordinator.data.get("account_number")
 
 
-class AmeriGasServiceAddressSensor(AmeriGasSensorBase):
-    """Service address sensor."""
+class AmeriGasDeliveryAddressSensor(AmeriGasSensorBase):
+    """Delivery address sensor."""
 
-    _attr_name = "Service Address"
-    _attr_unique_id = "amerigas_service_address"
+    _attr_name = "Delivery Address"
+    _attr_unique_id = "amerigas_delivery_address"
     _attr_icon = "mdi:home-map-marker"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def native_value(self) -> str | None:
-        """Return service address."""
-        return self.coordinator.data.get("service_address")
+        """Return delivery address."""
+        return self.coordinator.data.get("delivery_address")
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/amerigas/sensor.py
+++ b/custom_components/amerigas/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
-    Platform,
     UnitOfEnergy,
     UnitOfVolume,
     UnitOfVolumeFlowRate,
@@ -45,21 +44,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AmeriGas sensors based on a config entry."""
-    from homeassistant.helpers import entity_registry as er
-
-    # Migrate old service_address sensor to delivery_address
-    entity_reg = er.async_get(hass)
-
-    # Try both with and without entry_id prefix in case the integration ever used either
-    for old_unique_id, new_unique_id in [
-        ("amerigas_service_address", "amerigas_delivery_address"),
-        (f"{entry.entry_id}_amerigas_service_address", f"{entry.entry_id}_amerigas_delivery_address")
-    ]:
-        old_entity_id = entity_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, old_unique_id)
-        if old_entity_id:
-            _LOGGER.debug(f"Migrating AmeriGas sensor unique_id from {old_unique_id} to {new_unique_id}")
-            entity_reg.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
-
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     # Base sensors from API
@@ -78,6 +62,7 @@ async def async_setup_entry(
         AmeriGasAutoPaySensor(coordinator, entry.entry_id),
         AmeriGasPaperlessSensor(coordinator, entry.entry_id),
         AmeriGasAccountNumberSensor(coordinator, entry.entry_id),
+        AmeriGasServiceAddressSensor(coordinator, entry.entry_id),
         AmeriGasDeliveryAddressSensor(coordinator, entry.entry_id),
     ]
 
@@ -605,6 +590,30 @@ class AmeriGasAccountNumberSensor(AmeriGasSensorBase):
         return self.coordinator.data.get("account_number")
 
 
+class AmeriGasServiceAddressSensor(AmeriGasSensorBase):
+    """Service address sensor."""
+
+    _attr_name = "Service Address"
+    _attr_unique_id = "amerigas_service_address"
+    _attr_icon = "mdi:home-map-marker"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> str | None:
+        """Return service address."""
+        return self.coordinator.data.get("service_address")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra attributes."""
+        return {
+            "street": self.coordinator.data.get("street"),
+            "city": self.coordinator.data.get("city"),
+            "state": self.coordinator.data.get("state"),
+            "zip": self.coordinator.data.get("zip"),
+        }
+
+
 class AmeriGasDeliveryAddressSensor(AmeriGasSensorBase):
     """Delivery address sensor."""
 
@@ -617,16 +626,6 @@ class AmeriGasDeliveryAddressSensor(AmeriGasSensorBase):
     def native_value(self) -> str | None:
         """Return delivery address."""
         return self.coordinator.data.get("delivery_address")
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return extra attributes."""
-        return {
-            "street": self.coordinator.data.get("street"),
-            "city": self.coordinator.data.get("city"),
-            "state": self.coordinator.data.get("state"),
-            "zip": self.coordinator.data.get("zip"),
-        }
 
 
 # =============================================================================


### PR DESCRIPTION
This PR resolves issue #26 where will-call customers noticed their "Service Address" was showing their billing address. Based on the user's feedback, the term "Service Address" is retained as it reflects the API's naming convention, but a new "Delivery Address" sensor has been added. The delivery address is parsed directly from the dashboard HTML.

Changes:
- Extracted `DeliveryAddressHTML` from the dashboard page via regex.
- Updated `const.py` and `api.py` to support `delivery_address`.
- Created a new `AmeriGasDeliveryAddressSensor` and added it to `sensor.py`.

---
*PR created automatically by Jules for task [7822670036563755205](https://jules.google.com/task/7822670036563755205) started by @skircr115*